### PR TITLE
Fix: 修复 Obsidian API 升级导致的 getSyncViewState 错误

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -1,4 +1,4 @@
-import { MarkdownView, Plugin, WorkspaceLeaf } from 'obsidian';
+import { MarkdownView, Plugin, WorkspaceLeaf, OpenViewState } from 'obsidian';
 
 const MarkdownViewScrollOffset = Symbol('MarkdownViewScrollOffset');
 const MarkdownViewScrollGroup = Symbol('MarkdownViewScrollGroup');
@@ -13,7 +13,6 @@ declare module 'obsidian' {
 	interface MarkdownView {
 		syncState(this: MarkdownView, sameType: boolean): Promise<boolean>;
 		getScrollOffsetForSync(this: MarkdownView, group: string): number;
-		getSyncViewState(this: MarkdownView): OpenViewState;
 		[MarkdownViewScrollOffset]: number | undefined;
 		[MarkdownViewScrollGroup]: string | undefined;
 	}
@@ -41,7 +40,11 @@ export default class MarkdownSyncScrollPlugin extends Plugin {
             const leaf = this.leaf as unknown as WorkspaceLeaf;
             const group = leaf.group;
             if (!group) return false;
-            const syncViewState = this.getSyncViewState();
+            // Build OpenViewState from current view state (replacing removed getSyncViewState method)
+            const syncViewState: OpenViewState = {
+                state: this.getState(),
+                eState: this.getEphemeralState()
+            };
             const currentScroll = this.currentMode.getScroll();
             const srcScrollOffset = this.getScrollOffsetForSync(group);
             let success = true;

--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,8 @@
 {
 	"id": "markdown-sync-scroll",
 	"name": "Markdown Sync Scroll",
-	"version": "0.1.0",
-	"minAppVersion": "1.3.5",
+	"version": "0.2.0",
+	"minAppVersion": "1.11.7",
 	"description": "Allow two linked markdown views to scroll synchronously.",
 	"author": "ProjectXero",
 	"authorUrl": "https://github.com/XeroAlpha/",


### PR DESCRIPTION
## 问题
Obsidian API 升级后，`getSyncViewState()` 方法已被删除，导致插件在新版本 Obsidian (v1.11.7+) 中无法正常工作。

报错信息：
```
Uncaught (in promise) TypeError: this.getSyncViewState is not a function
    at import_obsidian.MarkdownView.syncState (plugin:markdown-sync-scroll:54:34)
    at t.sync.n.layout.n.history.n.done (app.js:1:1366300)
    at t.<anonymous> (app.js:1:1405486)
    at app.js:1:258511
    at Object.next (app.js:1:258616)
    at a (app.js:1:257334)
```


## 解决方案
- 移除对已删除的 `getSyncViewState()` 方法的调用
- 使用 `getState()` 和 `getEphemeralState()` 组合构建 `OpenViewState`
- 已在 Obsidian v1.12.2 测试通过

## 变更内容
- **main.ts**: 修复 API 兼容性问题（9行改动，+6/-3）
- **manifest.json**: 版本号从 0.1.0 升级到 0.2.0

## 测试
- [x] 在 Obsidian v1.12.2 中测试通过